### PR TITLE
feat(@angular/cli) override suite in the protractor config

### DIFF
--- a/packages/@angular/cli/commands/e2e.ts
+++ b/packages/@angular/cli/commands/e2e.ts
@@ -13,6 +13,7 @@ export interface E2eTaskOptions extends ServeTaskOptions {
   serve: boolean;
   webdriverUpdate: boolean;
   specs: string[];
+  suite: string;
   elementExplorer: boolean;
 }
 
@@ -43,15 +44,15 @@ const E2eCommand = Command.extend({
       `
     },
     {
-      name: 'specs',
-      type: Array,
-      default: [],
-      aliases: ['sp'],
+      name: 'suite',
+      type: String,
+      aliases: ['su'],
       description: oneLine`
-        Override specs in the protractor config.
-        Can send in multiple specs by repeating flag (ng e2e --specs=spec1.ts --specs=spec2.ts).
+        Override suite in the protractor config.
+        Can send in multiple suite by comma seperated values (ng e2e --suite=suite1.ts, suite2.ts).
       `
     },
+
     {
       name: 'element-explorer',
       type: Boolean,


### PR DESCRIPTION
feat(@angular/cli) override suite in the protractor config

resolves: 807
Override suite in the protractor config.
Can send in multiple suite by comma seperated values (ng e2e --suite=suite1.ts, suite2.ts).

Issue link
 github.com/angular/angular-cli/issues/807
 github.com/angular/angular-cli/pull/3551